### PR TITLE
 changed workQueue due to rejection of new tasks

### DIFF
--- a/application/src/main/java/org/thingsboard/server/udp/service/context/DefaultLbContext.java
+++ b/application/src/main/java/org/thingsboard/server/udp/service/context/DefaultLbContext.java
@@ -23,8 +23,8 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -40,7 +40,9 @@ public class DefaultLbContext implements LbContext {
     @PostConstruct
     public void init() {
         scheduler = Executors.newSingleThreadScheduledExecutor(ThingsBoardThreadFactory.forName("lb-scheduler"));
-        executor =  new ThreadPoolExecutor(1, Runtime.getRuntime().availableProcessors(), 60L, TimeUnit.SECONDS, new SynchronousQueue(), ThingsBoardThreadFactory.forName("lb-executor"));
+        int coreSize = Runtime.getRuntime().availableProcessors();
+        executor =  new ThreadPoolExecutor(coreSize, coreSize, 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), ThingsBoardThreadFactory.forName("lb-executor"));
+        ((ThreadPoolExecutor)executor).allowCoreThreadTimeOut(true);
     }
 
     @PreDestroy


### PR DESCRIPTION
```
java.util.concurrent.RejectedExecutionException: Task CallbackListener{org.thingsboard.server.udp.service.UdpClientLbHandler$1@19e677d5} rejected from java.util.concurrent.ThreadPoolExecutor@6cca9eb7[Running, pool size = 12, active threads = 0, queued tasks = 0, completed tasks = 85426]
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2055)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:825)
	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(ThreadPoolExecutor.java:1355)
	at com.google.common.util.concurrent.ImmediateFuture.addListener(ImmediateFuture.java:47)
	at com.google.common.util.concurrent.Futures.addCallback(Futures.java:1045)
	at org.thingsboard.server.udp.service.UdpClientLbHandler.channelRead0(UdpClientLbHandler.java:46)
	at org.thingsboard.server.udp.service.UdpClientLbHandler.channelRead0(UdpClientLbHandler.java:32)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioMessageChannel$NioMessageUnsafe.read(AbstractNioMessageChannel.java:97)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:719)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:655)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:581)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:493)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:986)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:829)
```