### PR TITLE
fixed wrong DNS update

### DIFF
--- a/application/src/main/java/org/thingsboard/server/udp/service/resolve/AbstractResolver.java
+++ b/application/src/main/java/org/thingsboard/server/udp/service/resolve/AbstractResolver.java
@@ -63,11 +63,11 @@ public abstract class AbstractResolver implements Resolver {
                 newAddresses = doResolve(hostname);
                 if (newAddresses == null || newAddresses.isEmpty()) {
                     log.warn("DNS address: {} resolves to empty list!", hostname);
-                    newAddresses = Collections.emptyList();
+                    return;
                 }
             } catch (Exception e) {
                 log.warn("Failed to resolve the DNS address: {}", hostname, e);
-                newAddresses = Collections.emptyList();
+                return;
             }
             Set<InetAddress> removedAddresses = new HashSet<>(oldAddresses);
             removedAddresses.removeAll(newAddresses);


### PR DESCRIPTION
[tb-coap-transport] DNS record update from [tb-coap-transport/17.2.1.13] to [] detected. 
Result after wrong update [CoAP]: [/1.1.1.1:15683][null][57556][1636706369577][/1.1.1.1:15683][null]